### PR TITLE
Fix malformed config.json sample

### DIFF
--- a/config.json.sample
+++ b/config.json.sample
@@ -1,4 +1,4 @@
-
+{
   "global": {
     "db_host": "localhost",
     "db_user": "parts_admin",


### PR DESCRIPTION
The config.json.sample file is malformed and caused the following error:

```
ubuntu@ip-172-31-94-160:~/vexu_parts$ bundle exec rake db:migrate
Warning: using Pathological, but no Pathfile was found.
rake aborted!
JSON::ParserError: 757: unexpected token at '"global": {
    "db_host": "localhost",
    "db_user": "root",
    "db_database": "vexu_parts",
    "port": 8080,
    "base_address": "http://ec2-35-171-154-140.compute-1.amazonaws.com",
    "gmail_user": "wpivexu.noreply@gmail.com",
    "enable_wordpress_auth": false,
    "slack_enabled": false,
    "slack_api_token": "",
    "trello_enabled": false,
    "trello_public": "",
    "trello_member": "",
    "enable_ordering": false
    },
  "dev": {
    "db_password": "root_pass_01",
    "gmail_password": "root_pass_01",
    "members_url": ""
  },
  "prod": {
    "db_password": "root_pass_01",
    "gmail_password": "root_pass_01",
    "members_url": ""
  }
}
'
/home/ubuntu/.rvm/gems/ruby-2.3.7/gems/json-1.8.3/lib/json/common.rb:155:in `parse'
/home/ubuntu/.rvm/gems/ruby-2.3.7/gems/json-1.8.3/lib/json/common.rb:155:in `parse'
/home/ubuntu/.rvm/gems/ruby-2.3.7/bundler/gems/cheesy-common-3b67984fe653/lib/config.rb:17:in `all_configs'
/home/ubuntu/.rvm/gems/ruby-2.3.7/bundler/gems/cheesy-common-3b67984fe653/lib/config.rb:38:in `block in method_missing'
/home/ubuntu/.rvm/gems/ruby-2.3.7/bundler/gems/cheesy-common-3b67984fe653/lib/config.rb:37:in `each'
/home/ubuntu/.rvm/gems/ruby-2.3.7/bundler/gems/cheesy-common-3b67984fe653/lib/config.rb:37:in `method_missing'
/home/ubuntu/vexu_parts/db.rb:8:in `<top (required)>'
/home/ubuntu/vexu_parts/Rakefile:15:in `require_relative'
/home/ubuntu/vexu_parts/Rakefile:15:in `block (2 levels) in <top (required)>'
/home/ubuntu/.rvm/gems/ruby-2.3.7/bin/ruby_executable_hooks:15:in `eval'
/home/ubuntu/.rvm/gems/ruby-2.3.7/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```