### PR TITLE
fix some big dum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3
+FROM ruby:2.3.8
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile-migrations
+++ b/Dockerfile-migrations
@@ -1,4 +1,4 @@
-FROM ruby:2.3
+FROM ruby:2.3.8
 
 WORKDIR /usr/src/app
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,4 +114,4 @@ DEPENDENCIES
   thin
 
 BUNDLED WITH
-   1.17.2
+   1.17

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To run Deep Blue Parts in a container:
 1. Make sure Docker is running.
 1. Populate `config.json` with parameters for the dev and prod environments. `config.json.docker` contains all the presets you would need to run with the provided `docker-compose.yml`. Feel free to change the database, username, and password fields, as long as you do it in both the config and compose files.
 1. Run `docker-compose up -d web`. This will build and run your Deep Blue Parts server in the background.
-1. Run `docker-compose run migration`. This will perform the database migration operations that are needed. You may need to run this more than once if an error occurs.
+1. Run `docker-compose run migrations`. This will perform the database migration operations that are needed. You may need to run this more than once if an error occurs.
 1. You're now ready to access the DBP server at `localhost:9000`! 
 1. See the text below the Development instructions to login.
 1. When you want to stop the server, you can do so with `docker-compose down`.

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ Prerequisites:
 To run Deep Blue Parts in a container:
 
 1. Make sure Docker is running.
-2. Populate `config.json` with parameters for the dev and prod environments. `config.json.docker` contains all the presets you would need to run with the provided `docker-compose.yml`. Feel free to change the database, username, and password fields, as long as you do it in both the config and compose files.
-3. Find your private IP address. (Instructions in [Linux](https://www.linuxtrainingacademy.com/determine-public-ip-address-command-line-curl/), [Mac OS](http://osxdaily.com/2010/11/21/find-ip-address-mac/), [Windows](https://www.howtogeek.com/117371/how-to-find-your-computers-private-public-ip-addresses/)) and set that as `db-host` in `config.json`.
-4. Run `docker-compose up -d web`. This will build and run your Deep Blue Parts server in the background.
-5. Run `docker-compose run migration`. This will perform the database migration operations that are needed. You may need to run this more than once if an error occurs.
-6. You're now ready to access the DBP server at `localhost:9000` (or whatever port you set the config to)!
-7. When you want to stop the server, you can do so with `docker-compose down`.
+1. Populate `config.json` with parameters for the dev and prod environments. `config.json.docker` contains all the presets you would need to run with the provided `docker-compose.yml`. Feel free to change the database, username, and password fields, as long as you do it in both the config and compose files.
+1. Run `docker-compose up -d web`. This will build and run your Deep Blue Parts server in the background.
+1. Run `docker-compose run migration`. This will perform the database migration operations that are needed. You may need to run this more than once if an error occurs.
+1. You're now ready to access the DBP server at `localhost:9000`! 
+1. See the text below the Development instructions to login.
+1. When you want to stop the server, you can do so with `docker-compose down`.
 
 ## Development
 

--- a/config.json.docker
+++ b/config.json.docker
@@ -1,6 +1,6 @@
 {
   "global": {
-    "db_host": "127.0.0.1",
+    "db_host": "db",
     "db_user": "parts_admin",
     "db_database": "parts",
     "port": 9000,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   db:
     image: mysql:5.7
     volumes:
-      - db_data:/var/lib/mysql
+      - parts_db:/var/lib/mysql
     restart: always
     ports:
       - "3306:3306"
@@ -32,4 +32,4 @@ services:
     restart: on-failure
 
 volumes:
-  db_data:
+  parts_db:


### PR DESCRIPTION
- use specific ruby version in case ruby does a sneaky on us and updates ruby 2.3 and breaks something
- make bundler version less specific because apparently bundler updated from 1.17.2 to 1.17.3 without us knowing
- MOST IMPORTANTLY: networking is so much easier now. no need for fancy public ip stuff