### PR TITLE
Fix issue #55 (add  CAD platform & drawing links)

### DIFF
--- a/db/migrations/019_add_cad_platform_to_projects.rb
+++ b/db/migrations/019_add_cad_platform_to_projects.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:projects) do
+      add_column :cad_platform, String, :default => "SOLIDWORKS", :null => false
+    end
+  end
+end

--- a/db/migrations/020_add_drawing_link_to_parts.rb
+++ b/db/migrations/020_add_drawing_link_to_parts.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:parts) do
+      add_column :drawing_link, String, :default => "", :null => false
+    end
+  end
+end

--- a/models/project.rb
+++ b/models/project.rb
@@ -6,4 +6,9 @@
 class Project < Sequel::Model
   one_to_many :parts
   one_to_many :orders
+
+  CAD_PLATFORM_MAP = { 
+    "Onshape" => "Onshape",
+    "SOLIDWORKS" => "SOLIDWORKS"
+  }
 end

--- a/parts_server.rb
+++ b/parts_server.rb
@@ -147,8 +147,11 @@ module CheesyParts
       # Check parameter existence and format.
       halt(400, "Missing project name.") if params[:name].nil?
       halt(400, "Missing part number prefix.") if params[:part_number_prefix].nil?
+      halt(400, "Missing CAD platform.") if params[:cad_platform].nil?
+      halt(400, "Invalid CAD platform.") unless Project::CAD_PLATFORM_MAP.include?(params[:cad_platform])
 
-      project = Project.create(:name => params[:name], :part_number_prefix => params[:part_number_prefix], :hide_dashboards => 0)
+      project = Project.create(:name => params[:name], :part_number_prefix => params[:part_number_prefix], :hide_dashboards => 0, 
+        :cad_platform => params[:cad_platform])
 
       redirect "/projects/#{project.id}"
     end
@@ -208,6 +211,11 @@ module CheesyParts
       @project.name = params[:name] if params[:name]
       if params[:part_number_prefix]
         @project.part_number_prefix = params[:part_number_prefix]
+      end
+
+      if params[:cad_platform]
+        halt(400, "Invalid CAD platform.") unless Project::CAD_PLATFORM_MAP.include?(params[:cad_platform])
+        @project.cad_platform = params[:cad_platform]
       end
 
       if params[:avatar]
@@ -420,6 +428,11 @@ module CheesyParts
           else
             @part.rev_history << ",#{@part.rev}"
           end
+          @part.drawing_created = 1
+        end
+
+        if params[:drawing_link]
+          @part.drawing_link = params[:drawing_link].strip
           @part.drawing_created = 1
         end
 

--- a/views/new_project.erb
+++ b/views/new_project.erb
@@ -13,6 +13,20 @@
     </div>
     <div class="row">
       <div class="col-2">
+        <label class="float-right">CAD Platform</label>
+      </div>
+      <div class="col-4">
+        <select name="cad_platform">
+	      <% Project::CAD_PLATFORM_MAP.each_pair do |key, value| %>
+		      <option value="<%= key %>"<% if "Onshape" == key %> selected<% end %>>
+		          <%= value %>
+		      </option>
+	      <% end %>
+        </select>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-2">
         <label class="float-right">Part Prefix</label>
       </div>
       <div class="col-4">

--- a/views/part.erb
+++ b/views/part.erb
@@ -61,7 +61,11 @@
         </tr>
         <tr>
           <td><b>Part Number</b></td>
+          <% if @part.drawing_created == 1 && @part.project.cad_platform == "Onshape" %>
+          <td><a href="<%= @part.drawing_link %>"><%= @part.full_part_number %></a></td>
+          <% else %>
           <td><%= @part.full_part_number %></td>
+          <% end %>
         </tr>
         <% if @part.type != "cots" %>
         <tr>
@@ -87,23 +91,25 @@
         <tr>
           <td><b>Quantity Required</b></td><td><%= @part.quantity %></td>
         </tr>
-        <% if @part.type != "cots" %>
+<% if @part.type != "cots" %>
 
         <tr>
 
           <td><b>Drawing Created?</b></td>
           <td><%= (@part.drawing_created == 1) ? "Yes" : "No" %></td>
         </tr>
+  <%if @part.project.cad_platform == "SOLIDWORKS" %>
         <tr>
           <td><b>Revision Letter</b></td>
           <td><%= @part.rev %></td>
         </tr>
-        <% end %>
-<%if @part.drawing_created == 1 %>
+    <%if @part.drawing_created == 1 %>
         <tr>
           <td><b>Drawing Link</b></td>
           <td><a href="<%= "/uploads/" + @part.full_part_number + "/drawing/" + @part.full_part_number + "_" + @part.rev + ".pdf" %>">Revision <%= @part.rev %></a></td>
         </tr>
+    <% end %>
+  <% end %>
 <% end %>
 <%if File.file?("./uploads/"+ @part.full_part_number + "/docs/" + @part.full_part_number + ".pdf") %>
         <tr>
@@ -158,7 +164,7 @@
 <% end %>
     </div><!-- /col-4 -->
     <div class="col-8 float-right">
-<%if @part.drawing_created == 1 %>
+<%if @part.drawing_created == 1 && @part.project.cad_platform == "SOLIDWORKS" %>
       <div class="embed-responsive embed-responsive-4by3">
         <object class="embed-responsive-item" data="<%= "/uploads/" + @part.full_part_number + "/drawing/" + @part.full_part_number + "_" + @part.rev + ".pdf" %>" type="application/pdf"></object>
       </div>

--- a/views/part_edit.erb
+++ b/views/part_edit.erb
@@ -44,7 +44,14 @@
       <input type="text" name="quantity" value="<%= @part.quantity %>" />
     </div>
     <% if @part.type != "cots" %>
-
+    <% if @part.project.cad_platform == "Onshape" %>
+    <div class="col">
+      <label class="float-right">Drawing Link</label>
+    </div>
+    <div class="col">
+      <input type="url" name="drawing_link" value="<%= @part.drawing_link %>" onblur="reportValidity(this)" />
+    </div>
+    <% else %>
     <div class="col">
       <label class="float-right">Reset Current Revision</label>
     </div>
@@ -57,6 +64,7 @@
         <% end %>
       </select>
     </div>
+    <% end %>
     <% end %>
   </div>
   <hr>
@@ -106,6 +114,7 @@
   <hr>
 	<fieldset>
     <div class="row">
+      <% if @part.project.cad_platform == "SOLIDWORKS" %>
       <div class="col">
         <div class="row">
           <i class="mx-auto fas fa-ruler-combined fa-4x"></i>
@@ -116,6 +125,7 @@
           </label>
         </div>
       </div>
+      <% end %>
       <div class="col">
         <div class="row">
           <i class="mx-auto far fa-file-alt fa-4x"></i>

--- a/views/project_edit.erb
+++ b/views/project_edit.erb
@@ -15,6 +15,20 @@
     </div>
     <div class="row">
       <div class="col-2">
+        <label class="float-right">CAD Platform</label>
+      </div>
+      <div class="col-4">
+        <select name="cad_platform">
+	      <% Project::CAD_PLATFORM_MAP.each_pair do |key, value| %>
+		      <option value="<%= key %>"<% if @project.cad_platform == key %> selected<% end %>>
+		          <%= value %>
+		      </option>
+	      <% end %>
+        </select>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-2">
         <label class="float-right">Part Prefix</label>
       </div>
       <div class="col-4">


### PR DESCRIPTION
Support per project CAD platform (Onshape or SOLIDWORKS).
Use drawing links instead of uploaded drawings for Onshape projects.

Tested locally and everything seems to work as expected.

@morops, can you give this a quick code review before it goes into production?
